### PR TITLE
Phase 1: Mobile Bottom Tab Navigation

### DIFF
--- a/ui/src/components/layout/AppLayout.jsx
+++ b/ui/src/components/layout/AppLayout.jsx
@@ -17,6 +17,7 @@ import Header from './Header';
 import Sidebar from './Sidebar';
 import Breadcrumbs from './Breadcrumbs';
 import ChatInterface from '../chat/ChatInterface';
+import BottomNav from '../mobile/BottomNav';
 import { useAppContext } from '../../contexts/AppContext';
 
 const { Content } = Layout;
@@ -101,7 +102,7 @@ const AppLayout = () => {
       <Header />
       <Layout>
         {!isMobile && <Sidebar />}
-        <Layout style={{ padding: isMobile ? '0 12px 12px' : '0 24px 24px' }}>
+        <Layout style={{ padding: isMobile ? '0 12px 76px 12px' : '0 24px 24px' }}>
           <Breadcrumbs style={{ margin: '16px 0' }} />
           <Content
             style={{
@@ -116,6 +117,9 @@ const AppLayout = () => {
           </Content>
         </Layout>
       </Layout>
+
+      {/* Mobile Bottom Navigation */}
+      {isMobile && <BottomNav />}
 
       {/* Mobile Navigation Drawer */}
       <Drawer

--- a/ui/src/components/mobile/BottomNav.css
+++ b/ui/src/components/mobile/BottomNav.css
@@ -1,0 +1,71 @@
+/**
+ * Bottom Navigation Styles
+ * Mobile-only fixed bottom tab bar
+ */
+
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  background: #ffffff;
+  border-top: 1px solid #f0f0f0;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  z-index: 999;
+  padding-bottom: env(safe-area-inset-bottom);
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.bottom-nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  height: 100%;
+  border: none;
+  background: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: rgba(0, 0, 0, 0.45);
+  padding: 8px 4px;
+  min-width: 44px;
+}
+
+.bottom-nav-item:active {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.bottom-nav-item.active {
+  color: #1890ff;
+}
+
+.bottom-nav-icon {
+  font-size: 22px;
+  margin-bottom: 2px;
+  transition: transform 0.2s ease;
+}
+
+.bottom-nav-item.active .bottom-nav-icon {
+  transform: scale(1.1);
+}
+
+.bottom-nav-label {
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 400;
+}
+
+.bottom-nav-item.active .bottom-nav-label {
+  font-weight: 500;
+}
+
+/* Hide on desktop */
+@media (min-width: 768px) {
+  .bottom-nav {
+    display: none;
+  }
+}

--- a/ui/src/components/mobile/BottomNav.jsx
+++ b/ui/src/components/mobile/BottomNav.jsx
@@ -1,0 +1,84 @@
+/**
+ * Bottom Tab Navigation for Mobile
+ * Fixed bottom navigation bar with primary app sections
+ */
+
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  DashboardOutlined,
+  FileTextOutlined,
+  SafetyCertificateOutlined,
+  ExclamationCircleOutlined,
+  MenuOutlined,
+} from '@ant-design/icons';
+import { useAppContext } from '../../contexts/AppContext';
+import './BottomNav.css';
+
+const BottomNav = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { toggleMobileDrawer } = useAppContext();
+
+  // Determine active tab based on current path
+  const getActiveTab = () => {
+    const path = location.pathname;
+    if (path === '/') return 'dashboard';
+    if (path.startsWith('/quotes')) return 'quotes';
+    if (path.startsWith('/policies')) return 'policies';
+    if (path.startsWith('/claims')) return 'claims';
+    return '';
+  };
+
+  const activeTab = getActiveTab();
+
+  const navItems = [
+    {
+      key: 'dashboard',
+      icon: <DashboardOutlined />,
+      label: 'Dashboard',
+      onClick: () => navigate('/'),
+    },
+    {
+      key: 'quotes',
+      icon: <FileTextOutlined />,
+      label: 'Quotes',
+      onClick: () => navigate('/quotes'),
+    },
+    {
+      key: 'policies',
+      icon: <SafetyCertificateOutlined />,
+      label: 'Policies',
+      onClick: () => navigate('/policies'),
+    },
+    {
+      key: 'claims',
+      icon: <ExclamationCircleOutlined />,
+      label: 'Claims',
+      onClick: () => navigate('/claims'),
+    },
+    {
+      key: 'more',
+      icon: <MenuOutlined />,
+      label: 'More',
+      onClick: toggleMobileDrawer,
+    },
+  ];
+
+  return (
+    <div className="bottom-nav">
+      {navItems.map((item) => (
+        <button
+          key={item.key}
+          className={`bottom-nav-item ${activeTab === item.key ? 'active' : ''}`}
+          onClick={item.onClick}
+          aria-label={item.label}
+        >
+          <span className="bottom-nav-icon">{item.icon}</span>
+          <span className="bottom-nav-label">{item.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default BottomNav;


### PR DESCRIPTION
Implements Phase 1 of #5 - Mobile Polish

### Changes
- Added fixed bottom tab navigation for mobile devices
- 5 tabs: Dashboard, Quotes, Policies, Claims, More
- Touch-friendly 44px targets with iOS safe-area support
- Active state indicators and smooth animations
- More tab opens existing drawer for Payments/Cases

Closes #5 (Phase 1)

🤖 Generated with [Claude Code](https://claude.ai/code)