### PR TITLE
Fix: Use git diff for detect-changes on closed PRs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -89,28 +89,34 @@ jobs:
     timeout-minutes: 5
 
     outputs:
-      infrastructure_changed: ${{ steps.filter.outputs.infrastructure }}
+      infrastructure_changed: ${{ steps.check.outputs.infrastructure_changed }}
       stack_exists: ${{ steps.check-stack.outputs.stack_exists }}
 
     steps:
-      - name: Checkout PR
+      - name: Checkout merged commit
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-          fetch-depth: 0
+          fetch-depth: 2
 
-      - name: Detect file changes in PR
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          base: ${{ github.event.pull_request.base.sha || 'main' }}
-          filters: |
-            infrastructure:
-              - 'cdk/**'
-              - 'lambda/**'
-              - 'scripts/**'
-              - '.github/workflows/deploy-production.yml'
-              - '.github/actions/**'
+      - name: Detect infrastructure changes
+        id: check
+        run: |
+          # For merged PRs, compare merge commit with its parent
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Check files changed in the merge commit
+            if git diff --name-only HEAD^ HEAD | grep -E '^(cdk/|lambda/|scripts/|\.github/workflows/deploy-production\.yml|\.github/actions/)'; then
+              echo "infrastructure_changed=true" >> $GITHUB_OUTPUT
+              echo "✅ Infrastructure files changed"
+            else
+              echo "infrastructure_changed=false" >> $GITHUB_OUTPUT
+              echo "ℹ️ No infrastructure changes detected"
+            fi
+          else
+            # Manual dispatch - deploy infrastructure
+            echo "infrastructure_changed=true" >> $GITHUB_OUTPUT
+            echo "Manual dispatch - will deploy infrastructure"
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Problem

After PR #56 merged, production workflow failed with:
- Error: "Resource not accessible by integration"
- Error: "base input parameter is ignored when action is triggered by pull request event"
- Failed run: https://github.com/SkyflowFoundry/Silvermoat/actions/runs/20645751108

## Root Cause

The `paths-filter` action cannot access PR data after the PR is closed/merged. 

When workflow triggers on `pull_request: [closed]`, the PR is already closed and GitHub Actions can't read PR file changes through the API.

## Solution

Replace `paths-filter` with `git diff` for infrastructure change detection:

**Before:**
```yaml
- uses: dorny/paths-filter@v3
  with:
    base: ${{ github.event.pull_request.base.sha }}
```

**After:**
```bash
git diff --name-only HEAD^ HEAD | grep infrastructure-patterns
```

This compares the merge commit (`HEAD`) with its parent (`HEAD^`) to detect changes.

## Why This Works

- ✅ No API access needed - uses git directly
- ✅ Works on closed/merged PRs
- ✅ Works on any commit
- ✅ Same functionality as paths-filter

## Testing

Will be tested when this PR merges (triggers same workflow).

## Note

This only affects **production workflow** because it uses `pull_request: [closed]`.

Test workflow still uses `paths-filter` successfully because it triggers on active PR events (`opened`, `synchronize`).

Fixes failed run from PR #56 merge.