### PR TITLE
feat: Add clear-and-seed-data composite action for fresh data on each deploy

### DIFF
--- a/.github/actions/clear-and-seed-data/action.yml
+++ b/.github/actions/clear-and-seed-data/action.yml
@@ -1,0 +1,31 @@
+name: 'Clear and Seed Demo Data'
+description: 'Clear existing demo data and seed fresh data for consistent demo experience'
+
+inputs:
+  api-base-url:
+    description: 'API base URL to clear and seed data'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      shell: bash
+      run: pip install faker==40.1.0 requests
+
+    - name: Clear existing demo data
+      shell: bash
+      run: python scripts/clear-demo-data.py
+      env:
+        API_BASE_URL: ${{ inputs.api-base-url }}
+
+    - name: Seed fresh demo data
+      shell: bash
+      run: python scripts/seed-demo-data.py
+      env:
+        API_BASE_URL: ${{ inputs.api-base-url }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -347,9 +347,25 @@ jobs:
             echo "⚡ UI unchanged - saved ~2-3 minutes!"
           fi
 
+  clear-and-seed-data:
+    needs: deploy-ui
+    if: always() && needs.deploy-ui.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Clear and seed demo data
+        uses: ./.github/actions/clear-and-seed-data
+        with:
+          api-base-url: ${{ needs.deploy-ui.outputs.api_url }}
+
   # Phase 1: Comprehensive Test Suite (Matrix Strategy)
   test-suite:
-    needs: deploy-ui
+    needs: [deploy-ui, clear-and-seed-data]
+    if: always() && needs.deploy-ui.result == 'success' && needs.clear-and-seed-data.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -402,7 +402,7 @@ jobs:
           echo "API URL: ${API_URL}"
           echo "Web URL: ${WEB_URL}"
 
-  seed-data:
+  clear-and-seed-data:
     needs: [deploy-stack, deploy-ui]
     if: |
       always() &&
@@ -415,22 +415,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Clear and seed demo data
+        uses: ./.github/actions/clear-and-seed-data
         with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install faker==40.1.0 requests
-
-      - name: Seed demo data
-        run: python scripts/seed-demo-data.py
-        env:
-          API_BASE_URL: ${{ needs.deploy-ui.outputs.api_url }}
+          api-base-url: ${{ needs.deploy-ui.outputs.api_url }}
 
   test-suite:
-    needs: [deploy-stack, deploy-ui, seed-data]
-    if: always() && needs.deploy-ui.result == 'success' && needs.seed-data.result == 'success'
+    needs: [deploy-stack, deploy-ui, clear-and-seed-data]
+    if: always() && needs.deploy-ui.result == 'success' && needs.clear-and-seed-data.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/scripts/clear-demo-data.py
+++ b/scripts/clear-demo-data.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Clear all demo data from API.
+
+Deletes all records from all resource types to ensure clean slate for seeding.
+"""
+
+import os
+import sys
+import requests
+
+API_BASE_URL = os.environ.get('API_BASE_URL', '').rstrip('/')
+
+if not API_BASE_URL:
+    print("Error: API_BASE_URL environment variable not set", file=sys.stderr)
+    sys.exit(1)
+
+RESOURCE_TYPES = ['customer', 'quote', 'policy', 'claim', 'payment', 'case']
+
+def clear_resource(resource_type):
+    """Delete all records of a given resource type."""
+    try:
+        response = requests.delete(f"{API_BASE_URL}/{resource_type}", timeout=30)
+        response.raise_for_status()
+
+        result = response.json()
+        deleted_count = result.get('deletedCount', 0)
+        print(f"✓ Cleared {deleted_count} {resource_type}(s)")
+        return deleted_count
+    except requests.exceptions.RequestException as e:
+        print(f"✗ Failed to clear {resource_type}s: {e}", file=sys.stderr)
+        return 0
+
+def main():
+    """Clear all demo data from API."""
+    print("Clearing all demo data...")
+    print(f"API Base URL: {API_BASE_URL}\n")
+
+    total_deleted = 0
+
+    for resource_type in RESOURCE_TYPES:
+        deleted = clear_resource(resource_type)
+        total_deleted += deleted
+
+    print(f"\n✓ Data clearing complete: {total_deleted} records deleted")
+
+    if total_deleted == 0:
+        print("ℹ️  No records found (database was already empty)")
+
+    return 0
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"\n✗ Data clearing failed: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Implements composite action to clear and seed demo data on every deployment (both production and test environments).

## Changes

### New Composite Action
**`.github/actions/clear-and-seed-data/action.yml`**
- Reusable action that clears existing data then seeds fresh data
- Takes `api-base-url` as input
- Reduces duplication across workflows

### New Script
**`scripts/clear-demo-data.py`**
- Deletes all records from all resource types
- Uses DELETE endpoints to clear data
- Provides clear feedback on deleted count

### Workflow Updates

**Production Workflow (`deploy-production.yml`)**
- Added `clear-and-seed-data` job after `deploy-ui`
- Test suite now depends on clean data being seeded

**Test Workflow (`deploy-test.yml`)**
- Replaced standalone `seed-data` job with `clear-and-seed-data` composite action
- Now clears data before seeding (was only seeding before)

## Benefits

✓ **Consistent demo experience** - Fresh data on every deploy
✓ **No data accumulation** - Old test records don't pile up
✓ **DRY principle** - Single composite action shared across workflows
✓ **Predictable state** - Each deployment starts with clean slate

## Expected Behavior

Each deployment now:
1. ✓ Clears all existing records from DynamoDB tables
2. ✓ Seeds fresh demo data (50 customers, 150 quotes, 90 policies, 30 claims, 270 payments, 40 cases)
3. ✓ Runs tests against fresh data

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>