### PR TITLE
fix: Center mobile homepage cards

### DIFF
--- a/ui/src/pages/Landing/Landing.jsx
+++ b/ui/src/pages/Landing/Landing.jsx
@@ -67,7 +67,7 @@ const Landing = () => {
           </Paragraph>
         </div>
 
-        <Row gutter={[32, 32]} style={{ width: '100%' }}>
+        <Row gutter={[16, 16]} justify="center">
           <Col xs={24} sm={24} md={12}>
             <Card
               hoverable


### PR DESCRIPTION
Fixes #70

Updated the Row component in Landing.jsx to:
- Remove unnecessary width style
- Add justify="center" for proper centering
- Reduce gutter from 32px to 16px for mobile optimization

Generated with [Claude Code](https://claude.ai/code)