### PR TITLE
Move clear-and-seed-data to run after test suite

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -347,25 +347,10 @@ jobs:
             echo "⚡ UI unchanged - saved ~2-3 minutes!"
           fi
 
-  clear-and-seed-data:
-    needs: deploy-ui
-    if: always() && needs.deploy-ui.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Clear and seed demo data
-        uses: ./.github/actions/clear-and-seed-data
-        with:
-          api-base-url: ${{ needs.deploy-ui.outputs.api_url }}
-
   # Phase 1: Comprehensive Test Suite (Matrix Strategy)
   test-suite:
-    needs: [deploy-ui, clear-and-seed-data]
-    if: always() && needs.deploy-ui.result == 'success' && needs.clear-and-seed-data.result == 'success'
+    needs: [deploy-ui]
+    if: always() && needs.deploy-ui.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -435,6 +420,21 @@ jobs:
             echo "${{ matrix.test-type }} tests failed"
             exit 1
           fi
+
+  clear-and-seed-data:
+    needs: [deploy-ui, test-suite]
+    if: always() && needs.deploy-ui.result == 'success' && needs.test-suite.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Clear and seed demo data
+        uses: ./.github/actions/clear-and-seed-data
+        with:
+          api-base-url: ${{ needs.deploy-ui.outputs.api_url }}
 
   # Phase 4: Verify Deployment with Enhanced Reporting
   verify-deployment:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -402,27 +402,9 @@ jobs:
           echo "API URL: ${API_URL}"
           echo "Web URL: ${WEB_URL}"
 
-  clear-and-seed-data:
-    needs: [deploy-stack, deploy-ui]
-    if: |
-      always() &&
-      (needs.deploy-stack.result == 'success' || needs.deploy-stack.result == 'skipped') &&
-      needs.deploy-ui.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Clear and seed demo data
-        uses: ./.github/actions/clear-and-seed-data
-        with:
-          api-base-url: ${{ needs.deploy-ui.outputs.api_url }}
-
   test-suite:
-    needs: [deploy-stack, deploy-ui, clear-and-seed-data]
-    if: always() && needs.deploy-ui.result == 'success' && needs.clear-and-seed-data.result == 'success'
+    needs: [deploy-stack, deploy-ui]
+    if: always() && needs.deploy-ui.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -511,6 +493,25 @@ jobs:
             echo "${{ matrix.test-type }} tests failed"
             exit 1
           fi
+
+  clear-and-seed-data:
+    needs: [deploy-stack, deploy-ui, test-suite]
+    if: |
+      always() &&
+      (needs.deploy-stack.result == 'success' || needs.deploy-stack.result == 'skipped') &&
+      needs.deploy-ui.result == 'success' &&
+      needs.test-suite.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Clear and seed demo data
+        uses: ./.github/actions/clear-and-seed-data
+        with:
+          api-base-url: ${{ needs.deploy-ui.outputs.api_url }}
 
   analyze-results:
     needs: [deploy-stack, test-suite]


### PR DESCRIPTION
## Summary
- Move `clear-and-seed-data` job to run **after** test suite instead of before
- Tests create their own data (some cleanup fails, leaving +36 extra records)
- New approach: Clear after tests to ensure clean baseline for next deployment

## Why This Is The Right Approach

### Tests Are Self-Contained ✅
- **All tests create their own data** via fixtures (`created_quote`, etc.) or manual POST requests
- **No tests rely on pre-seeded data** - verified by checking all GET requests use created resources
- Tests with cleanup issues (negative tests, conditional cleanup) can leave data behind

### The +36 Extra Records
From test stack after full test run:
- customers: 54 (expected 50) → +4
- quotes: 161 (expected 150) → +11  
- policies: 96 (expected 90) → +6
- claims: 35 (expected 30) → +5
- payments: 275 (expected 270) → +5
- cases: 45 (expected 40) → +5

**Root cause:** Negative tests (marked `xfail`) and tests with conditional cleanup can leave data behind even when test suite passes.

## Changes
Both `deploy-test.yml` and `deploy-production.yml`:
- `test-suite` runs immediately after `deploy-ui` (tests run on whatever data exists)
- `clear-and-seed-data` runs after `test-suite` completes successfully
- Ensures clean 630-record baseline for next deployment

## Benefits
✅ Tests don't need perfect cleanup - more resilient  
✅ No test data accumulation between deployments  
✅ Clean baseline after every deployment cycle  
✅ Tests remain self-contained (don't rely on seeded data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)