### PR TITLE
Fix policy currency NaN display in customer portal

### DIFF
--- a/ui/src/pages/Customer/CustomerDashboard.jsx
+++ b/ui/src/pages/Customer/CustomerDashboard.jsx
@@ -120,15 +120,15 @@ const CustomerDashboard = () => {
     },
     {
       title: 'Coverage',
-      dataIndex: ['data', 'coverage_amount'],
+      dataIndex: ['data', 'coverageLimit_cents'],
       key: 'coverage',
-      render: (amount) => formatCurrency(amount * 100),
+      render: (amount) => formatCurrency(amount),
     },
     {
       title: 'Premium',
-      dataIndex: ['data', 'premium_annual'],
+      dataIndex: ['data', 'premium'],
       key: 'premium',
-      render: (amount) => formatCurrency(amount * 100),
+      render: (amount) => formatCurrency(amount),
     },
     {
       title: 'Effective Date',
@@ -173,7 +173,7 @@ const CustomerDashboard = () => {
       title: 'Amount',
       dataIndex: ['data', 'claim_amount'],
       key: 'claim_amount',
-      render: (amount) => formatCurrency(amount * 100),
+      render: (amount) => formatCurrency(amount),
     },
     {
       title: 'Status',
@@ -194,7 +194,7 @@ const CustomerDashboard = () => {
       title: 'Amount',
       dataIndex: ['data', 'amount'],
       key: 'amount',
-      render: (amount) => formatCurrency(amount * 100),
+      render: (amount) => formatCurrency(amount),
     },
     {
       title: 'Method',
@@ -279,7 +279,7 @@ const CustomerDashboard = () => {
               <Text type="secondary">Total Payments</Text>
               <Title level={2} style={{ margin: 0 }}>
                 {formatCurrency(
-                  payments.reduce((sum, p) => sum + ((p.data?.amount || 0) * 100), 0)
+                  payments.reduce((sum, p) => sum + (p.data?.amount || 0), 0)
                 )}
               </Title>
             </Space>


### PR DESCRIPTION
## Summary

Fixes #78 - Policy currency amounts showing NaN in customer portal.

### Changes
- Fix field name mismatches: `coverage_amount` → `coverageLimit_cents`, `premium_annual` → `premium`
- Remove incorrect `* 100` multipliers (values already in cents)
- Fix claim and payment amount rendering
- Fix total payments calculation

### Root Cause
CustomerDashboard.jsx expected different field names than what seed data provides, plus incorrectly multiplied cent values by 100. The `formatCurrency()` utility expects cents and handles division internally.

### Testing
Manual verification: Run seed data → check customer portal policies, claims, and payments display correctly.

Closes #78

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/SkyflowFoundry/Silvermoat/actions/runs/20677335982) | [Branch](https://github.com/SkyflowFoundry/Silvermoat/tree/claude/issue-78-20260103-1235