### PR TITLE
Split E2E tests into parallel jobs for better performance

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -411,17 +411,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-type: [smoke, api, e2e]
+        test-type: [smoke, api, e2e-smoke, e2e-forms, e2e-customer, e2e-navigation]
         include:
           - test-type: smoke
             test-dir: smoke
             needs-chrome: false
+            pytest-args: ""
           - test-type: api
             test-dir: api
             needs-chrome: false
-          - test-type: e2e
+            pytest-args: ""
+          - test-type: e2e-smoke
             test-dir: e2e
             needs-chrome: true
+            pytest-args: "-m smoke"
+          - test-type: e2e-forms
+            test-dir: e2e
+            needs-chrome: true
+            pytest-args: "-m forms"
+          - test-type: e2e-customer
+            test-dir: e2e
+            needs-chrome: true
+            pytest-args: "-m customer"
+          - test-type: e2e-navigation
+            test-dir: e2e
+            needs-chrome: true
+            pytest-args: "tests/test_landing_page.py -m 'e2e and not smoke'"
 
     steps:
       - name: Checkout code
@@ -467,7 +482,7 @@ jobs:
           set -o pipefail
           echo "Running ${{ matrix.test-type }} tests..."
           cd tests/${{ matrix.test-dir }}
-          pytest -v --tb=short 2>&1 | tee ../../${{ matrix.test-type }}-tests-output.txt
+          pytest -v --tb=short ${{ matrix.pytest-args }} 2>&1 | tee ../../${{ matrix.test-type }}-tests-output.txt
 
       - name: Upload test output
         if: always()


### PR DESCRIPTION
Closes #81

## Summary
- Split E2E tests into 4 parallel jobs by pytest marker
- Improves test execution time by running E2E tests concurrently
- No test code changes required (leverages existing markers)

## Changes
- Modified `.github/workflows/deploy-test.yml` matrix strategy
- Split `e2e` into 4 parallel jobs:
  - `e2e-smoke` (12 tests): Core smoke tests (`-m smoke`)
  - `e2e-forms` (7 tests): Form interactions (`-m forms`)
  - `e2e-customer` (2 tests): Customer portal (`-m customer`)
  - `e2e-navigation`: Landing page navigation tests (`-m 'e2e and not smoke'`)

## Expected Impact
- **Current**: ~21 tests sequential = 2-3.5 minutes
- **After**: ~5-7 tests per job in parallel = 30-70 seconds
- **Estimated speedup**: 60-70% reduction in E2E test time

## Test Plan
CI will validate parallel execution and timing improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)