### PR TITLE
Fix CloudFront cache invalidation for architecture diagram updates

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -255,12 +255,20 @@ jobs:
       - name: Get CloudFront distribution ID
         id: cloudfront
         run: |
-          # Extract distribution ID from UiDistribution resource
-          DISTRIBUTION_ID=$(aws cloudformation describe-stack-resources \
+          # Get distribution ID from CloudFormation output
+          DISTRIBUTION_ID=$(aws cloudformation describe-stacks \
             --stack-name silvermoat \
-            --logical-resource-id UiDistribution \
-            --query 'StackResources[0].PhysicalResourceId' \
+            --query 'Stacks[0].Outputs[?OutputKey==`CloudFrontDistributionId`].OutputValue' \
             --output text 2>/dev/null || echo "")
+
+          # Fallback to resource query for backwards compatibility during rollout
+          if [ -z "$DISTRIBUTION_ID" ] || [ "$DISTRIBUTION_ID" == "None" ]; then
+            echo "Output not found, trying resource query (fallback)..."
+            DISTRIBUTION_ID=$(aws cloudformation describe-stack-resources \
+              --stack-name silvermoat \
+              --query 'StackResources[?ResourceType==`AWS::CloudFront::Distribution`].PhysicalResourceId | [0]' \
+              --output text 2>/dev/null || echo "")
+          fi
 
           if [ -n "$DISTRIBUTION_ID" ] && [ "$DISTRIBUTION_ID" != "None" ]; then
             echo "distribution_id=${DISTRIBUTION_ID}" >> $GITHUB_OUTPUT

--- a/cdk/stacks/silvermoat_stack.py
+++ b/cdk/stacks/silvermoat_stack.py
@@ -168,6 +168,13 @@ class SilvermoatStack(Stack):
                 value=frontend.distribution.distribution_domain_name,
                 export_name=f"{self.stack_name}-CloudFrontDomain",
             )
+            CfnOutput(
+                self,
+                "CloudFrontDistributionId",
+                value=frontend.distribution.distribution_id,
+                export_name=f"{self.stack_name}-CloudFrontDistributionId",
+                description="CloudFront distribution ID for cache invalidation",
+            )
 
         if config.domain_name:
             CfnOutput(


### PR DESCRIPTION
Fixes #106

## Problem
Architecture diagram on production (https://silvermoat.net/architecture.png) shows outdated version despite being regenerated on every UI deployment.

**Root cause:** CloudFront cache invalidation fails because workflow cannot find distribution ID.

## Solution
Add CloudFormation Output for CloudFront distribution ID (stable, self-documenting approach).

## Changes

### 1. CDK Stack (`cdk/stacks/silvermoat_stack.py`)
- Added `CloudFrontDistributionId` output
- Conditional: only outputs when distribution exists
- Includes description for clarity

### 2. GitHub Actions Workflow (`.github/workflows/deploy-production.yml`)
- Query CloudFormation output for distribution ID (primary method)
- Fallback to resource type query for backwards compatibility
- Improved error handling and logging

## Testing Plan
- [x] Code changes complete
- [ ] CI/CD deploys stack with new output
- [ ] Workflow finds distribution ID via output
- [ ] CloudFront cache invalidation runs successfully
- [ ] Architecture diagram updates visible on production

## Rollout Strategy
Fallback ensures compatibility during deployment:
1. PR deploys new CDK stack → output available
2. Workflow first tries output (succeeds)
3. If output missing (shouldn't happen), falls back to resource query
4. After merge, future deployments use output exclusively

🤖 Generated with [Claude Code](https://claude.com/claude-code)