### PR TITLE
Add auto-plan for new issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,6 +11,41 @@ on:
     types: [submitted]
 
 jobs:
+  # Auto-generate plans for newly opened issues
+  claude-auto-plan:
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      !contains(github.event.issue.body, '@claude') &&
+      !contains(github.event.issue.title, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write  # Required to post plan comment
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Generate Implementation Plan
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Create an implementation plan for this issue following CLAUDE.md format:
+            1. Goal (1 line)
+            2. Assumptions (if any)
+            3. Phases (numbered, with file-level changes per phase)
+            4. Unresolved Questions (with recommended answers - REQUIRED)
+
+            Post the plan as an issue comment using task checkboxes for phases.
+
+            IMPORTANT: Do NOT execute any changes - only create and post the plan.
+
+  # Manual Claude invocation via @claude mentions
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
## Summary
Implements auto-planning for newly opened issues per #124

## Changes
- **New job:** `claude-auto-plan` triggers on `issues: [opened]`
- Auto-generates implementation plans following CLAUDE.md format
- Skips auto-plan if `@claude` already in issue (avoids duplication)
- Adds `issues: write` permission for posting plan comments
- Keeps existing `@claude` mention workflow unchanged

## Implementation Details
- Separate job from manual `@claude` invocations
- Custom prompt enforces plan-only mode (no execution)
- Follows CLAUDE.md requirements:
  - Goal (1 line)
  - Assumptions
  - Phases with file-level changes
  - Unresolved questions with recommendations

## Testing Plan
1. Merge PR to main
2. Open test issue to verify auto-plan triggers
3. Verify manual `@claude` mention still works

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)