### PR TITLE
Fix auto-plan: pass issue context to Claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,13 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Create an implementation plan for this issue following CLAUDE.md format:
+            Create an implementation plan for issue #${{ github.event.issue.number }} following CLAUDE.md format:
+
+            Issue Title: ${{ github.event.issue.title }}
+            Issue Body:
+            ${{ github.event.issue.body }}
+
+            Plan Requirements:
             1. Goal (1 line)
             2. Assumptions (if any)
             3. Phases (numbered, with file-level changes per phase)


### PR DESCRIPTION
Fixes auto-plan workflow - Claude now receives issue title and body in the prompt.

Previously Claude had no context about the issue, now it can generate proper plans.