### PR TITLE
Separate auto-plan into dedicated workflow

### DIFF
--- a/.github/workflows/auto-plan.yml
+++ b/.github/workflows/auto-plan.yml
@@ -1,0 +1,81 @@
+name: Auto-Plan Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  generate-plan:
+    # Only run if @claude is not already in issue (avoid duplication)
+    if: |
+      !contains(github.event.issue.body, '@claude') &&
+      !contains(github.event.issue.title, '@claude')
+    runs-on: ubuntu-latest
+    outputs:
+      plan: ${{ steps.generate.outputs.plan }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Generate implementation plan
+        id: generate
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--allowed-tools Bash(gh issue comment:*)'
+          prompt: |
+            Create an implementation plan for issue #${{ github.event.issue.number }} following CLAUDE.md format.
+
+            Issue Title: ${{ github.event.issue.title }}
+
+            Issue Body:
+            ${{ github.event.issue.body }}
+
+            Plan Requirements:
+            1. Goal (1 line)
+            2. Assumptions (if any)
+            3. Phases (numbered, with file-level changes per phase)
+            4. Unresolved Questions (with recommended answers - REQUIRED)
+
+            Format the plan in markdown with task checkboxes for phases.
+
+            IMPORTANT:
+            - Post the plan as a comment using: gh issue comment ${{ github.event.issue.number }} --body "<plan>"
+            - Do NOT execute any implementation changes
+            - ONLY create and post the plan
+
+  post-status:
+    needs: [generate-plan]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Post completion status
+        if: needs.generate-plan.result == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '✅ Auto-plan completed. See plan comment above.'
+            });
+
+      - name: Post failure status
+        if: needs.generate-plan.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❌ Auto-plan failed. You can manually trigger planning by mentioning `@claude` in a comment.'
+            });

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,47 +11,6 @@ on:
     types: [submitted]
 
 jobs:
-  # Auto-generate plans for newly opened issues
-  claude-auto-plan:
-    if: |
-      github.event_name == 'issues' &&
-      github.event.action == 'opened' &&
-      !contains(github.event.issue.body, '@claude') &&
-      !contains(github.event.issue.title, '@claude')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write  # Required to post plan comment
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Generate Implementation Plan
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
-            Create an implementation plan for issue #${{ github.event.issue.number }} following CLAUDE.md format:
-
-            Issue Title: ${{ github.event.issue.title }}
-            Issue Body:
-            ${{ github.event.issue.body }}
-
-            Plan Requirements:
-            1. Goal (1 line)
-            2. Assumptions (if any)
-            3. Phases (numbered, with file-level changes per phase)
-            4. Unresolved Questions (with recommended answers - REQUIRED)
-
-            Post the plan as an issue comment using task checkboxes for phases.
-
-            IMPORTANT: Do NOT execute any changes - only create and post the plan.
-
-  # Manual Claude invocation via @claude mentions
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -88,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Changes
- **Reverted** `claude.yml` to @claude-mention-only triggers
- **Created** new `auto-plan.yml` workflow with multi-step approach

## New Workflow Architecture

### Job 1: generate-plan
- Uses Claude Code action
- Grants access to `gh issue comment` command via `claude_args`
- Passes issue title and body to Claude
- Claude explicitly instructed to post plan using: `gh issue comment $issue --body "<plan>"`

### Job 2: post-status
- Runs after generate-plan (always)
- Posts success/failure status comment
- Helps users know if auto-plan worked

## Benefits
- Clean separation of concerns
- Explicit gh CLI permissions
- Better error handling
- Status feedback to users

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)