### PR TITLE
Add emoji reactions to auto-plan workflow

### DIFF
--- a/.github/workflows/auto-plan.yml
+++ b/.github/workflows/auto-plan.yml
@@ -15,8 +15,20 @@ jobs:
       plan: ${{ steps.generate.outputs.plan }}
     permissions:
       contents: read
+      issues: write  # Required for reaction
       id-token: write
     steps:
+      - name: Add eyes reaction to show workflow started
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              content: 'eyes'
+            });
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -56,6 +68,36 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Add rocket reaction on success
+        if: needs.generate-plan.result == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Remove eyes reaction
+            const reactions = await github.rest.reactions.listForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const eyesReaction = reactions.data.find(r => r.content === 'eyes' && r.user.type === 'Bot');
+            if (eyesReaction) {
+              await github.rest.reactions.deleteForIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                reaction_id: eyesReaction.id
+              });
+            }
+
+            // Add rocket reaction
+            await github.rest.reactions.createForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              content: 'rocket'
+            });
+
       - name: Post completion status
         if: needs.generate-plan.result == 'success'
         uses: actions/github-script@v7
@@ -66,6 +108,36 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: '✅ Auto-plan completed. See plan comment above.'
+            });
+
+      - name: Add confused reaction on failure
+        if: needs.generate-plan.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Remove eyes reaction
+            const reactions = await github.rest.reactions.listForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const eyesReaction = reactions.data.find(r => r.content === 'eyes' && r.user.type === 'Bot');
+            if (eyesReaction) {
+              await github.rest.reactions.deleteForIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                reaction_id: eyesReaction.id
+              });
+            }
+
+            // Add confused reaction
+            await github.rest.reactions.createForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              content: 'confused'
             });
 
       - name: Post failure status


### PR DESCRIPTION
## Changes
Adds visual feedback to auto-plan workflow via emoji reactions:

- 👀 **Eyes** - Added immediately when workflow starts
- 🚀 **Rocket** - Replaces eyes when plan generation succeeds  
- 😕 **Confused** - Replaces eyes when plan generation fails

## Benefits
- Users see immediate feedback when issue is opened
- Clear visual status indicator (no need to check Actions tab)
- Follows common GitHub bot patterns

## Implementation
- Added `issues: write` permission to generate-plan job
- New first step: Add eyes reaction
- Post-status job removes eyes and adds completion reaction
- Works for both success and failure cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)