### PR TITLE
Add prominent Web URL callout to PR summary

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -368,7 +368,28 @@ jobs:
           **PR**: #${{ github.event.pull_request.number }}
           **Workflow Run**: [View Details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
+          EOF
+
+          # Add prominent Web URL box if deployment succeeded
+          UI_RESULT="${{ needs.deploy-ui.result }}"
+          SEED_RESULT="${{ needs.clear-and-seed-data.result }}"
+          if [ "$UI_RESULT" = "success" ] && [ "$SEED_RESULT" = "success" ]; then
+            cat >> /tmp/pr-comment.md <<EOF
           ---
+
+          ### 🌐 **Test Environment Ready**
+
+          **Web URL:** ${{ needs.deploy-ui.outputs.web_url }}
+
+          **API URL:** ${{ needs.deploy-ui.outputs.api_url }}
+
+          Demo data has been seeded. You can now test your changes!
+
+          ---
+          EOF
+          fi
+
+          cat >> /tmp/pr-comment.md <<'EOF'
 
           ### 📦 Infrastructure Deployment
           EOF


### PR DESCRIPTION
## Changes
Adds a prominent callout box to PR summary comments displaying the Web URL after deployment completes.

## Before
Web URL was shown in the UI Deployment section, but buried in details.

## After
```markdown
### 🌐 **Test Environment Ready**

**Web URL:** http://silvermoat-test-pr-129-storagestackuibucket4ab0e1f-94iq2zsyynpq.s3-website-us-east-1...

**API URL:** https://57qtb76xkj.execute-api.us-east-1.amazonaws.com/demo/

Demo data has been seeded. You can now test your changes!
```

Displays prominently at the top of PR summary when:
- UI deployment succeeds
- Data seeding succeeds

Makes test environment immediately accessible!

🤖 Generated with [Claude Code](https://claude.com/claude-code)