### PR TITLE
Fix PR summary: remove duplicate URLs and job timing

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -436,12 +436,12 @@ jobs:
           UI_RESULT="${{ needs.deploy-ui.result }}"
           if [ "$UI_RESULT" = "success" ]; then
             echo "✅ **Deployed** - UI built and deployed successfully" >> /tmp/pr-comment.md
-            echo "- Web URL: ${{ needs.deploy-ui.outputs.web_url }}" >> /tmp/pr-comment.md
-            echo "- API URL: ${{ needs.deploy-ui.outputs.api_url }}" >> /tmp/pr-comment.md
           elif [ "$UI_RESULT" = "skipped" ]; then
             echo "⏭️ **Skipped** - UI deployment was skipped" >> /tmp/pr-comment.md
           elif [ "$UI_RESULT" = "failure" ]; then
             echo "❌ **Failed** - UI deployment failed" >> /tmp/pr-comment.md
+            echo "- Web URL: ${{ needs.deploy-ui.outputs.web_url }}" >> /tmp/pr-comment.md
+            echo "- API URL: ${{ needs.deploy-ui.outputs.api_url }}" >> /tmp/pr-comment.md
           else
             echo "⚠️ **${UI_RESULT}** - Unexpected status" >> /tmp/pr-comment.md
           fi
@@ -484,90 +484,10 @@ jobs:
 
           ---
 
-          ### ⏱️ Job Timing
-          EOF
-
-          # Get job timing from GitHub API
-          echo "Fetching job timings..." >> /tmp/pr-comment.md
-          echo "" >> /tmp/pr-comment.md
-
-          cat >> /tmp/pr-comment.md <<'EOF'
-
-          ---
-
           <sub>🤖 Auto-generated summary from test deployment workflow</sub>
           EOF
 
           echo "Generated comment:"
-          cat /tmp/pr-comment.md
-
-      - name: Fetch job timing from GitHub API
-        id: timing
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Fetch workflow run jobs
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
-            > /tmp/jobs.json
-
-          # Extract timing for key jobs
-          echo "| Job | Duration | Status |" > /tmp/timing.md
-          echo "|-----|----------|--------|" >> /tmp/timing.md
-
-          # Parse job data (looking for specific job names)
-          for job_name in "deploy-stack" "deploy-ui" "unit-tests" "api-tests" "e2e-tests" "clear-and-seed-data"; do
-            # Get job info
-            JOB_DATA=$(jq -r --arg name "$job_name" '.jobs[] | select(.name | contains($name)) | "\(.conclusion)|\(.started_at)|\(.completed_at)"' /tmp/jobs.json | head -1)
-
-            if [ -n "$JOB_DATA" ]; then
-              CONCLUSION=$(echo "$JOB_DATA" | cut -d'|' -f1)
-              START=$(echo "$JOB_DATA" | cut -d'|' -f2)
-              END=$(echo "$JOB_DATA" | cut -d'|' -f3)
-
-              if [ "$END" != "null" ] && [ "$START" != "null" ]; then
-                # Calculate duration in seconds
-                START_SEC=$(date -u -d "$START" +%s 2>/dev/null || date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$START" +%s 2>/dev/null || echo "0")
-                END_SEC=$(date -u -d "$END" +%s 2>/dev/null || date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$END" +%s 2>/dev/null || echo "0")
-                DURATION=$((END_SEC - START_SEC))
-
-                # Format duration
-                if [ $DURATION -ge 60 ]; then
-                  MIN=$((DURATION / 60))
-                  SEC=$((DURATION % 60))
-                  DURATION_STR="${MIN}m ${SEC}s"
-                else
-                  DURATION_STR="${DURATION}s"
-                fi
-              else
-                DURATION_STR="in progress"
-              fi
-
-              # Status emoji
-              case "$CONCLUSION" in
-                success) STATUS="✅" ;;
-                failure) STATUS="❌" ;;
-                skipped) STATUS="⏭️" ;;
-                cancelled) STATUS="🚫" ;;
-                *) STATUS="⚠️" ;;
-              esac
-
-              echo "| $job_name | $DURATION_STR | $STATUS |" >> /tmp/timing.md
-            fi
-          done
-
-          echo "Timing table:"
-          cat /tmp/timing.md
-
-      - name: Insert timing into comment
-        run: |
-          # Replace placeholder with actual timing
-          sed -i '/Fetching job timings.../r /tmp/timing.md' /tmp/pr-comment.md
-          sed -i '/Fetching job timings.../d' /tmp/pr-comment.md
-
-          echo "Final comment:"
           cat /tmp/pr-comment.md
 
       - name: Post comment to PR


### PR DESCRIPTION
## Summary
- Remove duplicate URL display (Web URL and API URL now only appear in prominent callout box, not duplicated in UI Deployment section)
- Remove incomplete job timing table that was showing only headers

## Changes
- `.github/workflows/deploy-test.yml`:
  - UI Deployment section: only shows URLs on failure (they're already in "Test Environment Ready" callout on success)
  - Removed Job Timing section and related fetching/insertion steps

Fixes the issues identified in PR summary comments.