### PR TITLE
Fix landing domain: remove hardcoded silvermoat.com

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -440,7 +440,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           STACK_NAME: silvermoat-landing
-          DOMAIN_NAME: silvermoat.com
+          DOMAIN_NAME: silvermoat.net
         run: |
           echo "Running smart DNS update for landing (apex domain)..."
           chmod +x scripts/update-cloudflare-dns.sh

--- a/cdk/stacks/landing_stack.py
+++ b/cdk/stacks/landing_stack.py
@@ -49,7 +49,7 @@ class LandingStack(Stack):
         self.distribution = None
 
         if config.create_cloudfront and config.domain_name:
-            # Landing uses apex domain (silvermoat.com) instead of subdomain
+            # Landing uses apex domain instead of subdomain
             if config.domain_name.startswith("*"):
                 # Extract base domain for apex
                 base_domain = config.domain_name.lstrip("*").lstrip(".")

--- a/scripts/generate-architecture-diagram.py
+++ b/scripts/generate-architecture-diagram.py
@@ -58,7 +58,7 @@ def generate_architecture_diagram():
         # Landing Page
         with Cluster("Landing Page"):
             with Cluster("Frontend Distribution"):
-                landing_cloudfront = CloudFront("CloudFront\nsilvermoat.com")
+                landing_cloudfront = CloudFront("CloudFront\nsilvermoat.net")
                 landing_ui_bucket = S3("UI Bucket")
 
             landing_cloudfront >> landing_ui_bucket

--- a/scripts/update-cloudflare-dns.sh
+++ b/scripts/update-cloudflare-dns.sh
@@ -74,15 +74,17 @@ else
     CREATE_WILDCARD="${CREATE_WILDCARD:-false}"
 fi
 
-# Determine subdomain
+# Determine subdomain (no hardcoding - all use DOMAIN_NAME)
 if [[ "$VERTICAL" == "landing" ]]; then
-    # Landing uses apex domain
-    SUBDOMAIN="silvermoat.com"
+    # Landing uses apex domain (e.g., silvermoat.net)
+    SUBDOMAIN="${DOMAIN_NAME}"
     CLOUDFRONT_OUTPUT_KEY="LandingCloudFrontDomain"
 elif [[ -n "$VERTICAL" ]]; then
+    # Vertical-specific subdomain (insurance.silvermoat.net, retail.silvermoat.net)
     SUBDOMAIN="${VERTICAL}.${DOMAIN_NAME}"
     CLOUDFRONT_OUTPUT_KEY="${VERTICAL^}CloudFrontDomain"  # InsuranceCloudFrontDomain or RetailCloudFrontDomain
 else
+    # Fallback to root domain
     SUBDOMAIN="$DOMAIN_NAME"
     CLOUDFRONT_OUTPUT_KEY="CloudFrontDomain"
 fi


### PR DESCRIPTION
## Summary

Fixes hardcoded `silvermoat.com` references - landing should use `silvermoat.net` (apex domain).

## Problem

Landing page was hardcoded to use `silvermoat.com` in multiple places, but user only owns `silvermoat.net`:

1. **scripts/update-cloudflare-dns.sh** (line 80):
   ```bash
   SUBDOMAIN="silvermoat.com"  # ❌ Hardcoded
   ```

2. **.github/workflows/deploy-production.yml** (line 443):
   ```yaml
   DOMAIN_NAME: silvermoat.com  # ❌ Hardcoded
   ```

3. Comments and diagram labels also referenced .com

## Solution

**Remove all hardcoding** - use `DOMAIN_NAME` variable consistently:

- Landing: `silvermoat.net` (apex domain)
- Insurance: `insurance.silvermoat.net` (subdomain)
- Retail: `retail.silvermoat.net` (subdomain)

## Changes Made

### 1. DNS Script (`scripts/update-cloudflare-dns.sh`)
```bash
# Before:
SUBDOMAIN="silvermoat.com"

# After:
SUBDOMAIN="${DOMAIN_NAME}"  # Uses silvermoat.net from env
```

### 2. Production Workflow (`.github/workflows/deploy-production.yml`)
```yaml
# Before:
DOMAIN_NAME: silvermoat.com

# After:
DOMAIN_NAME: silvermoat.net
```

### 3. Landing Stack Comment (`cdk/stacks/landing_stack.py`)
- Updated comment to remove `.com` reference

### 4. Architecture Diagram (`scripts/generate-architecture-diagram.py`)
- Updated label: `silvermoat.com` → `silvermoat.net`

## DNS Record Management

The `update-cloudflare-dns.sh` script **already properly handles** both creating and updating DNS records:

- **Create new records** (POST) when record doesn't exist
- **Update existing records** (PUT) when record exists but target changed
- **Skip updates** when record already points to correct target

This will work correctly with verticalized DNS jobs in production workflow.

## Testing

- Will validate via CI/CD pipeline
- DNS script will create/update records as needed in Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)