### PR TITLE
Fix landing UI deployment dependencies

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -668,12 +668,14 @@ jobs:
 
   deploy-landing-ui:
     name: Deploy Landing UI
-    needs: [detect-changes, deploy-landing-infra, configure-landing-dns]
+    needs: [detect-changes, deploy-landing-infra, configure-landing-dns, deploy-insurance-ui, deploy-retail-ui]
     if: |
       always() &&
       (needs.deploy-landing-infra.result == 'success' || needs.deploy-landing-infra.result == 'skipped') &&
       (needs.configure-landing-dns.result == 'success' || needs.configure-landing-dns.result == 'skipped') &&
-      (needs.deploy-landing-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true')
+      (needs.deploy-landing-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true') &&
+      (needs.deploy-insurance-ui.result == 'success' || needs.deploy-insurance-ui.result == 'skipped') &&
+      (needs.deploy-retail-ui.result == 'success' || needs.deploy-retail-ui.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -142,11 +142,13 @@ jobs:
 
   deploy-landing-ui:
     name: Deploy Landing UI
-    needs: [detect-changes, deploy-landing-infra]
+    needs: [detect-changes, deploy-landing-infra, deploy-insurance-ui, deploy-retail-ui]
     if: |
       always() &&
       (needs.detect-changes.outputs.ui_changed == 'true' || needs.deploy-landing-infra.result == 'success' || inputs.force_deploy == 'true') &&
-      (needs.deploy-landing-infra.result == 'success' || needs.deploy-landing-infra.result == 'skipped')
+      (needs.deploy-landing-infra.result == 'success' || needs.deploy-landing-infra.result == 'skipped') &&
+      (needs.deploy-insurance-ui.result == 'success' || needs.deploy-insurance-ui.result == 'skipped') &&
+      (needs.deploy-retail-ui.result == 'success' || needs.deploy-retail-ui.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:


### PR DESCRIPTION
## Summary
- Fix landing E2E test failures by ensuring insurance/retail UIs deploy before landing UI
- Landing page needs insurance/retail URLs when building (fetched from CloudFormation)
- Updated both test and production workflows

## Changes
- `deploy-test.yml`: Added `deploy-insurance-ui`, `deploy-retail-ui` to `deploy-landing-ui` needs
- `deploy-production.yml`: Added `deploy-insurance-ui`, `deploy-retail-ui` to `deploy-landing-ui` needs

## Root Cause
Landing UI was deploying before insurance/retail UIs:
1. `deploy-landing-ui` ran first
2. `deploy-ui.sh` tried to fetch insurance/retail URLs from CloudFormation
3. Those stacks didn't exist yet → empty strings
4. Landing built with empty URLs
5. E2E tests failed (no links to click)

## Fix
Landing UI now waits for insurance/retail UIs to complete, ensuring URLs are available during build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)