### PR TITLE
Optimize workflows with composite action for infrastructure deployment

### DIFF
--- a/.github/actions/setup-infra-deploy/action.yml
+++ b/.github/actions/setup-infra-deploy/action.yml
@@ -1,0 +1,38 @@
+name: Setup Infrastructure Deployment
+description: Complete setup for CDK infrastructure deployment (Python, dependencies, AWS credentials, CDK)
+
+inputs:
+  aws-role-arn:
+    description: 'AWS IAM role ARN to assume for deployment'
+    required: true
+  aws-region:
+    description: 'AWS region for deployment'
+    required: false
+    default: 'us-east-1'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+        cache-dependency-path: requirements-test.txt
+
+    - name: Install dependencies
+      uses: ./.github/actions/install-deps
+      with:
+        install-ui: 'false'
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Setup AWS CDK
+      uses: ./.github/actions/setup-aws-cdk
+
+    - name: Bootstrap CDK
+      uses: ./.github/actions/bootstrap-cdk

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -190,29 +190,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup infrastructure deployment
+        uses: ./.github/actions/setup-infra-deploy
         with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements-test.txt
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          install-ui: 'false'
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Setup AWS CDK
-        uses: ./.github/actions/setup-aws-cdk
-
-      - name: Bootstrap CDK
-        uses: ./.github/actions/bootstrap-cdk
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy insurance production stack
         id: deploy
@@ -245,29 +226,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup infrastructure deployment
+        uses: ./.github/actions/setup-infra-deploy
         with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements-test.txt
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          install-ui: 'false'
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Setup AWS CDK
-        uses: ./.github/actions/setup-aws-cdk
-
-      - name: Bootstrap CDK
-        uses: ./.github/actions/bootstrap-cdk
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy retail production stack
         id: deploy
@@ -300,29 +262,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup infrastructure deployment
+        uses: ./.github/actions/setup-infra-deploy
         with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements-test.txt
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          install-ui: 'false'
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Setup AWS CDK
-        uses: ./.github/actions/setup-aws-cdk
-
-      - name: Bootstrap CDK
-        uses: ./.github/actions/bootstrap-cdk
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy landing production stack
         id: deploy

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -147,29 +147,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup infrastructure deployment
+        uses: ./.github/actions/setup-infra-deploy
         with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements-test.txt
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          install-ui: 'false'
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Setup AWS CDK
-        uses: ./.github/actions/setup-aws-cdk
-
-      - name: Bootstrap CDK
-        uses: ./.github/actions/bootstrap-cdk
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy landing stack
         id: deploy
@@ -259,29 +240,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup infrastructure deployment
+        uses: ./.github/actions/setup-infra-deploy
         with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements-test.txt
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          install-ui: 'false'
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Setup AWS CDK
-        uses: ./.github/actions/setup-aws-cdk
-
-      - name: Bootstrap CDK
-        uses: ./.github/actions/bootstrap-cdk
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy insurance stack
         id: deploy
@@ -402,29 +364,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup infrastructure deployment
+        uses: ./.github/actions/setup-infra-deploy
         with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements-test.txt
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          install-ui: 'false'
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Setup AWS CDK
-        uses: ./.github/actions/setup-aws-cdk
-
-      - name: Bootstrap CDK
-        uses: ./.github/actions/bootstrap-cdk
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Deploy retail stack
         id: deploy


### PR DESCRIPTION
## Summary

Consolidated repetitive infrastructure deployment setup steps into a reusable composite action, reducing workflow complexity and improving maintainability.

## Changes

### New Composite Action: `setup-infra-deploy`
Created `.github/actions/setup-infra-deploy/action.yml` that combines:
- Python 3.11 setup with pip caching
- Dependencies installation (Python only, no UI)
- AWS credentials configuration (takes role ARN as input)
- AWS CDK setup
- CDK bootstrapping

### Workflow Updates
**Before:**
```yaml
- name: Set up Python 3.11
  uses: actions/setup-python@v5
  with:
    python-version: '3.11'
    cache: 'pip'
    cache-dependency-path: requirements-test.txt

- name: Install dependencies
  uses: ./.github/actions/install-deps
  with:
    install-ui: 'false'

- name: Configure AWS credentials
  uses: aws-actions/configure-aws-credentials@v4
  with:
    role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
    aws-region: us-east-1

- name: Setup AWS CDK
  uses: ./.github/actions/setup-aws-cdk

- name: Bootstrap CDK
  uses: ./.github/actions/bootstrap-cdk
```

**After:**
```yaml
- name: Setup infrastructure deployment
  uses: ./.github/actions/setup-infra-deploy
  with:
    aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
```

### Jobs Updated
**Test Workflow (`deploy-test.yml`):**
- `deploy-landing-infra` - 6 steps → 2 steps
- `deploy-insurance-infra` - 6 steps → 2 steps
- `deploy-retail-infra` - 6 steps → 2 steps

**Production Workflow (`deploy-production.yml`):**
- `deploy-landing-infra` - 6 steps → 2 steps
- `deploy-insurance-infra` - 6 steps → 2 steps
- `deploy-retail-infra` - 6 steps → 2 steps

## Impact

**Lines of code:**
- **76 lines eliminated** from workflow files
- Net reduction: -76 lines across 2 workflows

**Maintenance benefits:**
- Single source of truth for infra setup
- Easier to update (change once, applies everywhere)
- Consistent setup across all 3 verticals
- Faster workflow authoring for future verticals

**Developer experience:**
- Simpler workflow files (less cognitive load)
- Clear intent (one step = "setup everything for infra deploy")
- Reduced chance of setup inconsistencies

## Testing

Workflow changes are non-functional (consolidation only):
- Same Python version (3.11)
- Same caching behavior (pip cache)
- Same AWS credentials flow
- Same CDK setup and bootstrap

The composite action will be tested by the CI run for this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)