### PR TITLE
Fix landing page DNS names and E2E test failures

### DIFF
--- a/tests/e2e/tests/test_landing_workflows.py
+++ b/tests/e2e/tests/test_landing_workflows.py
@@ -70,16 +70,19 @@ def test_landing_insurance_link(driver, landing_base_url):
     driver.get(landing_base_url)
     wait_for_app_ready(driver)
 
-    # Find insurance link by text content
-    insurance_links = driver.find_elements(By.XPATH, "//*[contains(text(), 'Insurance')]//ancestor-or-self::a[@href]")
-    if not insurance_links:
-        # Fallback: find any link near "Insurance" text
-        insurance_links = driver.find_elements(By.XPATH, "//a[contains(@href, 'insurance')]")
+    # Find all "Learn More" links/buttons with href
+    learn_more_links = driver.find_elements(By.XPATH, "//a[contains(., 'Learn More')][@href]")
 
-    assert len(insurance_links) > 0, "Should have insurance link"
+    # Get all hrefs
+    all_hrefs = [link.get_attribute('href') for link in learn_more_links]
+
+    # Find insurance link (should contain 'insurance' in URL)
+    insurance_links = [href for href in all_hrefs if href and 'insurance' in href.lower()]
+
+    assert len(insurance_links) > 0, f"Should have insurance link. Found links: {all_hrefs}"
 
     # Verify href is non-empty and valid (deployment-provided URL)
-    href = insurance_links[0].get_attribute('href')
+    href = insurance_links[0]
     assert href and len(href) > 0, "Insurance link should have valid href"
     assert href.startswith('http'), f"Insurance link should be absolute URL, got: {href}"
 
@@ -91,16 +94,19 @@ def test_landing_retail_link(driver, landing_base_url):
     driver.get(landing_base_url)
     wait_for_app_ready(driver)
 
-    # Find retail link by text content
-    retail_links = driver.find_elements(By.XPATH, "//*[contains(text(), 'Retail')]//ancestor-or-self::a[@href]")
-    if not retail_links:
-        # Fallback: find any link near "Retail" text
-        retail_links = driver.find_elements(By.XPATH, "//a[contains(@href, 'retail')]")
+    # Find all "Learn More" links/buttons with href
+    learn_more_links = driver.find_elements(By.XPATH, "//a[contains(., 'Learn More')][@href]")
 
-    assert len(retail_links) > 0, "Should have retail link"
+    # Get all hrefs
+    all_hrefs = [link.get_attribute('href') for link in learn_more_links]
+
+    # Find retail link (should contain 'retail' in URL)
+    retail_links = [href for href in all_hrefs if href and 'retail' in href.lower()]
+
+    assert len(retail_links) > 0, f"Should have retail link. Found links: {all_hrefs}"
 
     # Verify href is non-empty and valid (deployment-provided URL)
-    href = retail_links[0].get_attribute('href')
+    href = retail_links[0]
     assert href and len(href) > 0, "Retail link should have valid href"
     assert href.startswith('http'), f"Retail link should be absolute URL, got: {href}"
 


### PR DESCRIPTION
## Summary

Fixes two issues with the landing page:
1. Landing page now uses proper DNS names (insurance.silvermoat.net, retail.silvermoat.net) instead of CloudFront URLs
2. Fixes failing E2E tests that couldn't find vertical links

## Problem 1: CloudFront URLs instead of DNS names

**Before:**
Landing page showed CloudFront URLs like:
- `https://d1234abcd.cloudfront.net` (insurance)
- `https://d5678efgh.cloudfront.net` (retail)

**After:**
Landing page shows proper DNS names:
- `https://insurance.silvermoat.net`
- `https://retail.silvermoat.net`

**Root cause:**
The deploy-ui.sh script was only looking at the `WebUrl` CloudFormation output, which returns the CloudFront domain when CloudFront is enabled.

**Fix:**
Updated deploy-ui.sh to prefer `CustomDomainUrl` output (DNS name) over `WebUrl` (CloudFront), with fallback for environments without custom domains.

```bash
# Before: Only checked WebUrl
INSURANCE_WEB_URL=$(aws cloudformation describe-stacks \
  --query 'Stacks[0].Outputs[?OutputKey==`WebUrl`].OutputValue' ...)

# After: Prefer CustomDomainUrl, fallback to WebUrl
INSURANCE_WEB_URL=$(aws cloudformation describe-stacks \
  --query 'Stacks[0].Outputs[?OutputKey==`CustomDomainUrl`].OutputValue' ...)

if [ -z "$INSURANCE_WEB_URL" ]; then
  INSURANCE_WEB_URL=$(aws cloudformation describe-stacks \
    --query 'Stacks[0].Outputs[?OutputKey==`WebUrl`].OutputValue' ...)
fi
```

## Problem 2: E2E test failures

**Test failures:**
```
FAILED tests/test_landing_workflows.py::test_landing_insurance_link
FAILED tests/test_landing_workflows.py::test_landing_retail_link
AssertionError: Should have insurance link
assert 0 > 0
```

**Root cause:**
Tests were looking for links using incorrect XPath patterns that didn't match the actual DOM structure. Ant Design's Button component with `href` prop renders as an `<a>` tag.

**Before:**
```python
# This doesn't work - "Insurance" text is in Title, not in the link
insurance_links = driver.find_elements(
    By.XPATH, 
    "//*[contains(text(), 'Insurance')]//ancestor-or-self::a[@href]"
)
```

**After:**
```python
# Find "Learn More" links and filter by URL content
learn_more_links = driver.find_elements(By.XPATH, "//a[contains(., 'Learn More')][@href]")
all_hrefs = [link.get_attribute('href') for link in learn_more_links]
insurance_links = [href for href in all_hrefs if href and 'insurance' in href.lower()]
```

## Testing

Both issues will be validated by CI:
- Landing page build will receive CustomDomainUrl values
- E2E tests will find links correctly and verify they contain 'insurance' and 'retail' in URLs

## Files Changed

- `scripts/deploy-ui.sh`: Prefer CustomDomainUrl over WebUrl
- `tests/e2e/tests/test_landing_workflows.py`: Fix link detection logic in 2 tests

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)