### PR TITLE
Vertical-Aware Change Detection - Optimize CI/CD Pipeline

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -15,11 +15,35 @@ inputs:
 
 outputs:
   infrastructure:
-    description: 'Whether infrastructure files changed (true/false)'
+    description: 'Whether global infrastructure files changed (true/false)'
     value: ${{ steps.detect.outputs.infrastructure }}
+  insurance_lambda_changed:
+    description: 'Whether insurance Lambda files changed (true/false)'
+    value: ${{ steps.detect.outputs.insurance_lambda_changed }}
+  retail_lambda_changed:
+    description: 'Whether retail Lambda files changed (true/false)'
+    value: ${{ steps.detect.outputs.retail_lambda_changed }}
+  healthcare_lambda_changed:
+    description: 'Whether healthcare Lambda files changed (true/false)'
+    value: ${{ steps.detect.outputs.healthcare_lambda_changed }}
+  landing_lambda_changed:
+    description: 'Whether landing Lambda files changed (true/false)'
+    value: ${{ steps.detect.outputs.landing_lambda_changed }}
   ui:
-    description: 'Whether UI files changed (true/false)'
+    description: 'Whether global UI files changed (true/false)'
     value: ${{ steps.detect.outputs.ui }}
+  insurance_ui_changed:
+    description: 'Whether insurance UI files changed (true/false)'
+    value: ${{ steps.detect.outputs.insurance_ui_changed }}
+  retail_ui_changed:
+    description: 'Whether retail UI files changed (true/false)'
+    value: ${{ steps.detect.outputs.retail_ui_changed }}
+  healthcare_ui_changed:
+    description: 'Whether healthcare UI files changed (true/false)'
+    value: ${{ steps.detect.outputs.healthcare_ui_changed }}
+  landing_ui_changed:
+    description: 'Whether landing UI files changed (true/false)'
+    value: ${{ steps.detect.outputs.landing_ui_changed }}
   tests:
     description: 'Whether test files changed (true/false)'
     value: ${{ steps.detect.outputs.tests }}
@@ -69,22 +93,79 @@ runs:
         echo "$CHANGED_FILES"
         echo ""
 
-        # Infrastructure changes
-        if echo "$CHANGED_FILES" | grep -E '^(cdk/|lambda/|scripts/deploy-stack\.sh)'; then
+        # Global infrastructure changes (CDK, shared scripts)
+        if echo "$CHANGED_FILES" | grep -E '^(cdk/|scripts/deploy-stack\.sh)'; then
           echo "infrastructure=true" >> $GITHUB_OUTPUT
-          echo "✅ Infrastructure files changed"
+          echo "✅ Global infrastructure files changed"
         else
           echo "infrastructure=false" >> $GITHUB_OUTPUT
-          echo "ℹ️ No infrastructure changes"
+          echo "ℹ️ No global infrastructure changes"
         fi
 
-        # UI changes
-        if echo "$CHANGED_FILES" | grep -E '^(ui-insurance/|ui-retail/|ui-healthcare/|ui-landing/|scripts/generate-architecture-diagram\.py|scripts/deploy-ui\.sh)'; then
+        # Per-vertical Lambda changes
+        if echo "$CHANGED_FILES" | grep -E '^lambda/insurance/'; then
+          echo "insurance_lambda_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Insurance Lambda changed"
+        else
+          echo "insurance_lambda_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+        if echo "$CHANGED_FILES" | grep -E '^lambda/retail/'; then
+          echo "retail_lambda_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Retail Lambda changed"
+        else
+          echo "retail_lambda_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+        if echo "$CHANGED_FILES" | grep -E '^lambda/healthcare/'; then
+          echo "healthcare_lambda_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Healthcare Lambda changed"
+        else
+          echo "healthcare_lambda_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+        if echo "$CHANGED_FILES" | grep -E '^lambda/landing/'; then
+          echo "landing_lambda_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Landing Lambda changed"
+        else
+          echo "landing_lambda_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+        # Global UI changes (shared scripts)
+        if echo "$CHANGED_FILES" | grep -E '^(scripts/generate-architecture-diagram\.py|scripts/deploy-ui\.sh)'; then
           echo "ui=true" >> $GITHUB_OUTPUT
-          echo "✅ UI files changed"
+          echo "✅ Global UI scripts changed"
         else
           echo "ui=false" >> $GITHUB_OUTPUT
-          echo "ℹ️ No UI changes"
+        fi
+
+        # Per-vertical UI changes
+        if echo "$CHANGED_FILES" | grep -E '^ui-insurance/'; then
+          echo "insurance_ui_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Insurance UI changed"
+        else
+          echo "insurance_ui_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+        if echo "$CHANGED_FILES" | grep -E '^ui-retail/'; then
+          echo "retail_ui_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Retail UI changed"
+        else
+          echo "retail_ui_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+        if echo "$CHANGED_FILES" | grep -E '^ui-healthcare/'; then
+          echo "healthcare_ui_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Healthcare UI changed"
+        else
+          echo "healthcare_ui_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+        if echo "$CHANGED_FILES" | grep -E '^ui-landing/'; then
+          echo "landing_ui_changed=true" >> $GITHUB_OUTPUT
+          echo "✅ Landing UI changed"
+        else
+          echo "landing_ui_changed=false" >> $GITHUB_OUTPUT
         fi
 
         # Test changes

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -180,6 +180,7 @@ jobs:
       always() &&
       needs.detect-changes.result == 'success' &&
       (needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+       needs.detect-changes.outputs.insurance_lambda_changed == 'true' ||
        needs.detect-changes.outputs.insurance_stack_exists == 'false')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -216,6 +217,7 @@ jobs:
       always() &&
       needs.detect-changes.result == 'success' &&
       (needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+       needs.detect-changes.outputs.retail_lambda_changed == 'true' ||
        needs.detect-changes.outputs.retail_stack_exists == 'false')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -252,6 +254,7 @@ jobs:
       always() &&
       needs.detect-changes.result == 'success' &&
       (needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+       needs.detect-changes.outputs.healthcare_lambda_changed == 'true' ||
        needs.detect-changes.outputs.healthcare_stack_exists == 'false')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -288,6 +291,7 @@ jobs:
       always() &&
       needs.detect-changes.result == 'success' &&
       (needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+       needs.detect-changes.outputs.landing_lambda_changed == 'true' ||
        needs.detect-changes.outputs.landing_stack_exists == 'false')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -476,7 +480,7 @@ jobs:
       always() &&
       (needs.deploy-insurance-infra.result == 'success' || needs.deploy-insurance-infra.result == 'skipped') &&
       (needs.configure-insurance-dns.result == 'success' || needs.configure-insurance-dns.result == 'skipped') &&
-      (needs.deploy-insurance-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true')
+      (needs.deploy-insurance-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.insurance_ui_changed == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -586,7 +590,7 @@ jobs:
       always() &&
       (needs.deploy-retail-infra.result == 'success' || needs.deploy-retail-infra.result == 'skipped') &&
       (needs.configure-retail-dns.result == 'success' || needs.configure-retail-dns.result == 'skipped') &&
-      (needs.deploy-retail-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true')
+      (needs.deploy-retail-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.retail_ui_changed == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -696,7 +700,7 @@ jobs:
       always() &&
       (needs.deploy-healthcare-infra.result == 'success' || needs.deploy-healthcare-infra.result == 'skipped') &&
       (needs.configure-healthcare-dns.result == 'success' || needs.configure-healthcare-dns.result == 'skipped') &&
-      (needs.deploy-healthcare-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true')
+      (needs.deploy-healthcare-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.healthcare_ui_changed == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -845,7 +849,7 @@ jobs:
       always() &&
       (needs.deploy-landing-infra.result == 'success' || needs.deploy-landing-infra.result == 'skipped') &&
       (needs.configure-landing-dns.result == 'success' || needs.configure-landing-dns.result == 'skipped') &&
-      (needs.deploy-landing-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true') &&
+      (needs.deploy-landing-infra.result == 'success' || needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.landing_ui_changed == 'true') &&
       (needs.deploy-insurance-infra.result == 'success' || needs.deploy-insurance-infra.result == 'skipped') &&
       (needs.deploy-retail-infra.result == 'success' || needs.deploy-retail-infra.result == 'skipped') &&
       (needs.deploy-healthcare-infra.result == 'success' || needs.deploy-healthcare-infra.result == 'skipped')

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -135,6 +135,7 @@ jobs:
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+      needs.detect-changes.outputs.landing_lambda_changed == 'true' ||
       needs.detect-changes.outputs.landing_stack_exists == 'false' ||
       inputs.force_deploy == 'true'
     runs-on: ubuntu-latest
@@ -166,7 +167,7 @@ jobs:
     needs: [detect-changes, deploy-landing-infra, deploy-insurance-infra, deploy-retail-infra, deploy-healthcare-infra]
     if: |
       always() &&
-      (needs.detect-changes.outputs.ui_changed == 'true' || needs.deploy-landing-infra.result == 'success' || inputs.force_deploy == 'true') &&
+      (needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.landing_ui_changed == 'true' || needs.deploy-landing-infra.result == 'success' || inputs.force_deploy == 'true') &&
       (needs.deploy-landing-infra.result == 'success' || needs.deploy-landing-infra.result == 'skipped') &&
       (needs.deploy-insurance-ui.result == 'success' || needs.deploy-insurance-ui.result == 'skipped') &&
       (needs.deploy-retail-ui.result == 'success' || needs.deploy-retail-ui.result == 'skipped')
@@ -231,6 +232,7 @@ jobs:
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+      needs.detect-changes.outputs.insurance_lambda_changed == 'true' ||
       needs.detect-changes.outputs.insurance_stack_exists == 'false' ||
       inputs.force_deploy == 'true'
     runs-on: ubuntu-latest
@@ -262,7 +264,7 @@ jobs:
     needs: [detect-changes, deploy-insurance-infra]
     if: |
       always() &&
-      (needs.detect-changes.outputs.ui_changed == 'true' || needs.deploy-insurance-infra.result == 'success' || inputs.force_deploy == 'true') &&
+      (needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.insurance_ui_changed == 'true' || needs.deploy-insurance-infra.result == 'success' || inputs.force_deploy == 'true') &&
       (needs.deploy-insurance-infra.result == 'success' || needs.deploy-insurance-infra.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -355,6 +357,7 @@ jobs:
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+      needs.detect-changes.outputs.retail_lambda_changed == 'true' ||
       needs.detect-changes.outputs.retail_stack_exists == 'false' ||
       inputs.force_deploy == 'true'
     runs-on: ubuntu-latest
@@ -386,6 +389,7 @@ jobs:
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.infrastructure_changed == 'true' ||
+      needs.detect-changes.outputs.healthcare_lambda_changed == 'true' ||
       needs.detect-changes.outputs.healthcare_stack_exists == 'false' ||
       inputs.force_deploy == 'true'
     runs-on: ubuntu-latest
@@ -417,7 +421,7 @@ jobs:
     needs: [detect-changes, deploy-retail-infra]
     if: |
       always() &&
-      (needs.detect-changes.outputs.ui_changed == 'true' || needs.deploy-retail-infra.result == 'success' || inputs.force_deploy == 'true') &&
+      (needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.retail_ui_changed == 'true' || needs.deploy-retail-infra.result == 'success' || inputs.force_deploy == 'true') &&
       (needs.deploy-retail-infra.result == 'success' || needs.deploy-retail-infra.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -469,7 +473,7 @@ jobs:
     needs: [detect-changes, deploy-healthcare-infra]
     if: |
       always() &&
-      (needs.detect-changes.outputs.ui_changed == 'true' || needs.deploy-healthcare-infra.result == 'success' || inputs.force_deploy == 'true') &&
+      (needs.detect-changes.outputs.ui_changed == 'true' || needs.detect-changes.outputs.healthcare_ui_changed == 'true' || needs.deploy-healthcare-infra.result == 'success' || inputs.force_deploy == 'true') &&
       (needs.deploy-healthcare-infra.result == 'success' || needs.deploy-healthcare-infra.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
Complete overhaul of change detection to be fully vertical-aware, eliminating unnecessary deployments. When only Healthcare Lambda changes, only Healthcare infrastructure deploys - not Insurance, Retail, or Landing.

## Root Cause
Change detection used global flags (`infrastructure_changed`, `ui_changed`) that triggered deployments across ALL verticals, even when only one vertical's code changed. Example: `lambda/healthcare/handler.py` change triggered Insurance + Retail + Healthcare + Landing infra deployments.

## Solution: Vertical-Aware Detection

### New Detection Outputs
**Per-Vertical Lambda Flags:**
- `insurance_lambda_changed` - Detects `lambda/insurance/` changes
- `retail_lambda_changed` - Detects `lambda/retail/` changes
- `healthcare_lambda_changed` - Detects `lambda/healthcare/` changes
- `landing_lambda_changed` - Detects `lambda/landing/` changes

**Per-Vertical UI Flags:**
- `insurance_ui_changed` - Detects `ui-insurance/` changes
- `retail_ui_changed` - Detects `ui-retail/` changes
- `healthcare_ui_changed` - Detects `ui-healthcare/` changes
- `landing_ui_changed` - Detects `ui-landing/` changes

**Global Flags (affect ALL verticals):**
- `infrastructure` - Detects `cdk/` or `scripts/deploy-stack.sh` changes
- `ui` - Detects `scripts/deploy-ui.sh` or diagram generation changes

## Detailed Change Detection & Step Trigger Logic

### Infrastructure Deployment (Per Vertical)
**Triggers:** Deploy {vertical} infrastructure when:
1. Global infrastructure changed (`cdk/` or deploy scripts) **OR**
2. Vertical-specific Lambda changed (`lambda/{vertical}/`) **OR**
3. Stack doesn't exist yet (first deployment) **OR**
4. Force deploy flag set

**Example:** `lambda/healthcare/handler.py` change triggers:
- ✅ Healthcare infra deployment
- ❌ Insurance infra (skipped)
- ❌ Retail infra (skipped)
- ❌ Landing infra (skipped)

### UI Deployment (Per Vertical)
**Triggers:** Deploy {vertical} UI when:
1. Global UI scripts changed **OR**
2. Vertical-specific UI changed (`ui-{vertical}/`) **OR**
3. Infrastructure just deployed (infra job succeeded) **OR**
4. Force deploy flag set

**Example:** `ui-healthcare/src/pages/Dashboard.jsx` change triggers:
- ✅ Healthcare UI deployment
- ❌ Insurance UI (skipped)
- ❌ Retail UI (skipped)
- ❌ Landing UI (skipped)

### E2E Tests (Per Vertical)
**Triggers:** Run {vertical} E2E tests when:
- UI deployment succeeded (ALWAYS - no exceptions)

**Philosophy:** Tests MUST run every single time a UI is deployed, regardless of what triggered the deployment.

## Changes
- **.github/actions/detect-changes/action.yml**: Added 8 new per-vertical outputs
- **.github/workflows/deploy-test.yml**: Updated all vertical conditions
- **.github/workflows/deploy-production.yml**: Updated all vertical conditions

## Benefits
1. **Faster CI/CD**: Skips unnecessary deployments (healthcare change won't deploy insurance/retail)
2. **Lower AWS Costs**: Fewer Lambda deployments, CloudFormation updates
3. **Clearer Logs**: Only relevant jobs run
4. **Maintained Safety**: Tests still run for every UI deployment

## Test Plan
- [ ] Healthcare Lambda change → only Healthcare infra deploys
- [ ] Retail UI change → only Retail UI deploys
- [ ] CDK change → all infrastructure deploys (global change)
- [ ] Test workflow file change → all tests run (global test change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)